### PR TITLE
fixing bug when setting model parameters on creation

### DIFF
--- a/pyproffit/models.py
+++ b/pyproffit/models.py
@@ -238,7 +238,7 @@ class Model(object):
 
         if vals is not None:
 
-            if len(vals) != npar:
+            if len(vals) != self.npar:
 
                 print('Wrong number of parameters in input parameter vector, the provided function requires %d but the vector contains %d. Ignoring.' % (npar, len(vals)))
 


### PR DESCRIPTION
this should refer to self.npar instead of npar (as self.npar does not include the radius : model(x, *params))