### PR TITLE
profile.PSF : brentq root-finder should start to 0 in this case

### DIFF
--- a/pyproffit/profextract.py
+++ b/pyproffit/profextract.py
@@ -766,7 +766,7 @@ class Profile(object):
                 # psfmin = 0.
                 frmax = lambda x: psffunc(x) * 2. * np.pi * x / norm - psfmin
                 if frmax(exposure.shape[0] / 2) < 0.:
-                    rmax = brentq(frmax, 1., exposure.shape[0]) / self.data.pixsize  # pixsize
+                    rmax = brentq(frmax, 0., exposure.shape[0]) / self.data.pixsize  # pixsize
                     npix = int(rmax)
                 else:
                     npix = int(exposure.shape[0] / 2)


### PR DESCRIPTION
rmax finding should start from zero, peaked PSF function such as a Gaussian fade too quickly. 
the attached example psffunc returns an error because its rmax is less than 1 arcmin 

`def gaussian(x):`
`FWHM=5./60. # Full Width Half Maximum in arcmin`
`sigma=FWHM/2.35 # standard deviation as a function of the FWHM`
`return np.exp(-x**2/(2*sigma**2))`