### PR TITLE
do not plot the background profile if bkglink=None

### DIFF
--- a/pyproffit/profextract.py
+++ b/pyproffit/profextract.py
@@ -967,7 +967,7 @@ class Profile(object):
         if not scatter:
             plt.errorbar(rads, self.profile, xerr=self.ebins, yerr=self.eprof, fmt=fmt, color=data_color, elinewidth=2,
                          markersize=markersize, capsize=0, mec=data_color, label='Brightness', **kwargs)
-            if self.bkgprof is not None:
+            if self.data.bkglink is not None:
                 plt.plot(rads, self.bkgprof, color=bkg_color, lw=lw, label='Background')
             if model is not None and samples is None:
                 tmod = model(rads, *model.params)


### PR DESCRIPTION
As the background profile can never be None (see line 371), this if condition should verify whether a background image was provided in input to determine if the background profile should be plotted