### PR TITLE
fix plot_multi_methods when OP is used

### DIFF
--- a/pyproffit/deproject.py
+++ b/pyproffit/deproject.py
@@ -75,6 +75,8 @@ def plot_multi_methods(profs, deps, labels=None, outfile=None, xunit='kpc', figs
         dep = deps[i]
         prof = profs[i]
 
+        if dep.bkglim is None:
+            dep.bkglim = prof.bins[-1] + prof.ebins[-1]        
 
         kpcp = prof.cosmo.kpc_proper_per_arcmin(dep.z).value
 


### PR DESCRIPTION
Currently `test_script.py` crashes with

```
Traceback (most recent call last):
  File "/home/andrea/Software/0_DEV/pyproffit/validation/test_script.py", line 262, in <module>
    run()
  File "/home/andrea/Software/0_DEV/pyproffit/validation/test_script.py", line 218, in run
    pyproffit.plot_multi_methods(deps=(depr, deprop), profs=(prof, prof2),
  File "/home/andrea/Software/pyenv/versions/py3.12.7_pyproffit/lib/python3.12/site-packages/pyproffit/deproject.py", line 83, in plot_multi_methods
    sourcereg = np.where(prof.bins < dep.bkglim)
                         ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'float' and 'NoneType'
```

the reason is that `bkglim` is None for OP:

 https://github.com/domeckert/pyproffit/blob/d540796e286b0d1cd593103e3f70b8fbe0343924/validation/test_script.py#L202-L205

while it is a float for `pymc3` (and stan)

https://github.com/domeckert/pyproffit/blob/d540796e286b0d1cd593103e3f70b8fbe0343924/validation/test_script.py#L140

This makes `plot_multi_methods` crash with the error above. The proposed edit fixes the error forcing to use the full range of data when bkglim is None (i.e. in the case of OP). I am not sure if this is the best way to fix it, but it seems to work, and now `test_script.py` ends successfully (only deprecation warnings are raised). 